### PR TITLE
desc-pyspark kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+
 ## Current Kernels
 - desc-python
 - desc-python-dev
-- desc-spark
+- desc-pyspark
 - desc-stack
 - desc-stack-dev
 - desc-stack-old

--- a/desc-pyspark/README.md
+++ b/desc-pyspark/README.md
@@ -1,0 +1,10 @@
+# Apache Spark + DESC python kernel for Cori@NERSC
+
+This kernel allows DESC members to use the desc-python kernel with PySpark at NERSC.
+By default the kernel uses 4 threads. It has been generated using:
+https://github.com/astrolabsoftware/spark-kernel-nersc#apache-spark-kernel-for-desc-members-recommended
+
+The Apache Spark version in use is currently 2.3.2. This version is maintained by Julien Peloton at NERSC and it is not intended for running batch or interactive jobs. For that purpose see rather:
+https://github.com/LSSTDESC/desc-spark#working-at-nersc-batch-mode
+
+If you have trouble with this kernel, contact me (Julien Peloton, peloton@lal.in2p3.fr).

--- a/desc-pyspark/README.md
+++ b/desc-pyspark/README.md
@@ -8,3 +8,7 @@ The Apache Spark version in use is currently 2.3.2. This version is maintained b
 https://github.com/LSSTDESC/desc-spark#working-at-nersc-batch-mode
 
 If you have trouble with this kernel, contact me (Julien Peloton, peloton@lal.in2p3.fr).
+
+# Logbook
+
+- 12/11/2018: Initial release of the kernel.

--- a/desc-pyspark/desc-pyspark.sh
+++ b/desc-pyspark/desc-pyspark.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Where the Spark logs will be stored
+# Logs can be then be browsed from the Spark UI
+LOGDIR=${SCRATCH}/spark/event_logs
+mkdir -p ${LOGDIR}
+
+# The directory `/global/cscratch1/sd/<user>/tmpfiles` will be created if it
+# does not exist to store temporary files used by Spark.
+mkdir -p ${SCRATCH}/tmpfiles
+
+# Path to LSST miniconda installation at NERSC
+lSSTCONDA="/global/common/software/lsst/common/miniconda"
+
+# Since the default NERSC Apache Spark runs inside of Shifter, we use
+# a custom local version of it. This is maintained by me (Julien Peloton)
+# at NERSC. If you encounter problems, let me know (peloton at lal.in2p3.fr)!
+SPARKPATH="/global/homes/p/peloton/myspark/spark-2.3.2-bin-hadoop2.7"
+
+# Here is the environment needed for Spark to run at NERSC.
+export SPARK_HOME="${SPARKPATH}"
+export PYSPARK_SUBMIT_ARGS="--master local[4]   --driver-memory 32g --executor-memory 32g   --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
+export PYTHONSTARTUP="${SPARKPATH}/python/pyspark/shell.py"
+
+# Make sure the version of py4j is correct.
+export DESCPYTHONPATH="${SPARKPATH}/python/lib/py4j-0.10.7-src.zip:${SPARKPATH}/python"
+
+# Should correspond to desc-python
+export PYSPARK_PYTHON="${lSSTCONDA}/current/bin/python"
+export PYSPARK_DRIVER_PYTHON="${lSSTCONDA}/current/bin/ipython3"
+
+# We use Java 8. Spark 2+ does not work with Java 7 and earlier versions.
+export JAVA_HOME="/opt/java/jdk1.8.0_51"
+
+# desc-python activation script
+source ${lSSTCONDA}/kernels/python.sh
+    

--- a/desc-pyspark/kernel.json
+++ b/desc-pyspark/kernel.json
@@ -1,0 +1,8 @@
+{
+  "display_name": "desc-pyspark",
+  "language": "python",
+  "argv": [
+    "/global/common/software/lsst/common/miniconda/kernels/desc-pyspark.sh",
+    "-f",
+    "{connection_file}"]
+}


### PR DESCRIPTION
@heather999 This PR adds the `desc-pyspark` kernel. There are three files:

- The kernel `kernel.json`
- A startup script `desc-pyspark.sh`
- A README for further information

Note that I mimicked the other kernels, that is the startup script must be copied at `/global/common/software/lsst/common/miniconda/kernels` with a symlink to where the startup file will be versioned at NERSC (`/global/common/software/lsst/common/miniconda/kernels/versions/jupyter-kernels-current/desc-pyspark`). I have not done this step by myself, and it should be done after the merge.