### PR TITLE
Use a temp directory if $SCRATCH does not exist

### DIFF
--- a/desc-pyspark/desc-pyspark.sh
+++ b/desc-pyspark/desc-pyspark.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Where the Spark logs will be stored
 # Logs can be then be browsed from the Spark UI
+if [ -z ${SCRATCH} ]; then
+  SCRATCH=`mktemp -d`
+fi
 LOGDIR=${SCRATCH}/spark/event_logs
 mkdir -p ${LOGDIR}
 


### PR DESCRIPTION
When using the `desc-pyspark` kernel to run the notebooks with a cron job (which is how we validate/render the notebooks in https://github.com/LSSTDESC/DC2-analysis), the environment variable `$SCRATCH` does not exist, and hence the kernel won't start successfully. 

This PR adds a check on the existence of `$SCRATCH`, and, if it does not exist, make a temporary directory and assign `$SCRATCH` to it. 